### PR TITLE
fix(rating): 修复评课列表页顶部定位导致的显示 bug

### DIFF
--- a/src/components/common/FTabs.vue
+++ b/src/components/common/FTabs.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="f-tabs">
+  <div
+    ref="scroll"
+    class="f-tabs"
+  >
     <div class="f-tabs__header">
       <span
         v-for="tabPane in tabPanes"
@@ -22,6 +25,7 @@
 </template>
 
 <script lang="ts">
+import { useScrollToBottom } from '@/composables';
 import {
   defineComponent, ref,
 } from 'vue';
@@ -32,8 +36,10 @@ export default defineComponent({
   props: {
     /** (v-model) 激活的页面 key */
     modelValue: { type: String, required: true },
+    /** 距离底部多少 px 触发 on-scroll-to-bottom */
+    bottomOffset: { type: Number, default: 0 },
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'on-scroll-to-bottom'],
   setup(props, ctx) {
     const tabPanes = ref<{
       tab: string;
@@ -46,27 +52,12 @@ export default defineComponent({
       // children: (vNode.children as any)?.default?.() || null,
     }));
 
+    const { scrollRef: scroll } = useScrollToBottom(() => ctx.emit('on-scroll-to-bottom'), props.bottomOffset);
+
     return {
       tabPanes,
+      scroll,
     };
-  },
-  computed: {
-    // /** 计算下方悬浮 border 尺寸位置 */
-    // floatingBorderStyle(): Record<string, string> {
-    //   // 按照全角 key 计算
-    //   const fontSize = 17;
-    //   const paddingX = 12;
-    //   const width = this.modelValue.length * fontSize + 6;
-    //   const index = this.pageKeys.indexOf(this.modelValue);
-    //   if (index === -1) return {};
-    //   const pageKeysBefore = this.pageKeys.slice(0, index);
-    //   const totalLength = pageKeysBefore.reduce((pv, cv) => pv + cv.length, 0);
-    //   const left = pageKeysBefore.length * paddingX * 2 + paddingX + totalLength * fontSize - 3;
-    //   return {
-    //     width: `${width}px`,
-    //     left: `${left}px`,
-    //   };
-    // },
   },
   methods: {
     handleClickTab(pageKey: string) {
@@ -91,6 +82,7 @@ $padding-x: 12px;
   justify-content: stretch;
 
   > .f-tabs__header {
+    flex: 0 0 auto;
     overflow-x: auto;
     display: flex;
     justify-content: flex-start;
@@ -125,17 +117,6 @@ $padding-x: 12px;
         margin-left: 0;
       }
     }
-
-    // > .f-tabs__floating-border {
-    //   position: absolute;
-    //   bottom: 0;
-    //   left: 0;
-    //   height: 3px;
-    //   background-color: $primary-color;
-    //   border-radius: 1px;
-
-    //   transition: all 0.3s cubic-bezier(.4,0,.2,1);
-    // }
   }
 
   > .f-tabs__content {

--- a/src/composables/useScrollToBottom.ts
+++ b/src/composables/useScrollToBottom.ts
@@ -4,13 +4,16 @@ import debounce from 'lodash.debounce';
 /**
  * 使得对应 ref 的容器滚动到底部时触发回调函数
  * @param callback 滚动到底部时触发的回调函数
+ * @param bottom 距离底部多少 px 时执行回调，默认 0
  * @param delay 防抖延迟，默认 150
  */
 const useScrollToBottom: (
   callback: (() => void) | (() => Promise<void>),
+  bottom?: number,
   delay?: number,
 ) => { scrollRef: Ref<HTMLElement | undefined>; pending: Ref<boolean> } = (
   callback,
+  bottom = 0,
   delay = 150,
 ) => {
   const scrollRef = ref<HTMLElement>();
@@ -26,7 +29,7 @@ const useScrollToBottom: (
             return;
           }
           const { offsetHeight, scrollTop, scrollHeight } = el;
-          if (offsetHeight + scrollTop - scrollHeight >= -1) {
+          if (offsetHeight + scrollTop - scrollHeight >= -bottom - 1) {
             pending.value = true;
             // 需要执行的代码
             await callback();

--- a/src/views/Rating/Rating.vue
+++ b/src/views/Rating/Rating.vue
@@ -1,10 +1,13 @@
 <template>
   <div
-    ref="scroll"
     class="content-box"
   >
     <rating-head-bar />
-    <f-tabs v-model="activeTab">
+    <f-tabs
+      v-model="activeTab"
+      :bottom-offset="500"
+      @on-scroll-to-bottom="handleScrollToBottom"
+    >
       <f-tab-pane
         v-show="activeTab === '最新'"
         tab="最新"
@@ -43,7 +46,6 @@
 import { defineComponent, ref, watch } from 'vue';
 import { ratingClient, lectureClient } from '@/apis';
 import { CardLectureItem, CardRatingItem } from '@/components/listCard';
-import { useScrollToBottom } from '@/composables';
 import { RatingHeadBar, LectureList, RatingList } from './components';
 
 type TabType = '最新' | '通识' | '思政' | '外语' | '体育';
@@ -127,7 +129,7 @@ export default defineComponent({
     });
 
     // 滚动到底部时拉新数据
-    const { scrollRef: scroll } = useScrollToBottom(() => fetchMore(activeTab.value));
+    const handleScrollToBottom = () => fetchMore(activeTab.value);
 
     // 首次进入该页面拉数据
     fetchList(activeTab.value);
@@ -135,7 +137,7 @@ export default defineComponent({
     return {
       activeTab,
       tabLists,
-      scroll,
+      handleScrollToBottom,
     };
   },
 });
@@ -145,31 +147,28 @@ export default defineComponent({
 .content-box {
   height: 100%;
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   color: #444;
   font-size: 14px;
   margin: 0 auto;
   max-width: 2560px;
-  overflow-y: auto;
+  overflow-y: hidden;
 
   > .head-bar {
     background-color: #fff;
-    position: sticky;
-    top: 0;
-    z-index: 1;
   }
 }
 </style>
 
 <style lang="scss">
 .content-box > .f-tabs {
+  height: calc(100vh - 48px - 64px);
+  overflow-y: auto;
+
   > .f-tabs__header {
     padding: 15px 15px 6px 15px;
     background-color: #fff;
     position: sticky;
-    top: 48px;
+    top: 0;
     z-index: 1;
   }
 }


### PR DESCRIPTION
### Bug Fix

将评课列表页顶部定位由原本的双重 sticky 改为了 block + sticky，现在实际滚动元素为 FTabs 本身而非整个页面。

通过上述做法修复了两个问题：
- 由于双重 sticky 导致两个顶栏中间有一条会透出背后元素的缝隙
- 移动端 FTabs 的 header 会被压缩崩，原因是移动端浏览器处理 flexbox 布局中子元素溢出时自动加上了 `height: 0` 属性，而未设置 `flex-shrink: 0`

### 额外工作

- 为 `useScrollToBottom` 加入了 `bottom` 参数，用于在距离底部还有一定距离时提前执行回调函数以优化用户体验。
- 为 FTabs 引入了 scrollToBottom 相关逻辑，现在在 FTabs 本身到底时会抛出 `on-scroll-to-bottom` 事件，可以通过 `bottomOffset` props 传入 `bottom` 参数。