### PR TITLE
fix(timetable): 最老和最新学期不显示切换箭头

### DIFF
--- a/src/views/Timetable/Timetable.vue
+++ b/src/views/Timetable/Timetable.vue
@@ -59,6 +59,8 @@
     </a-drawer>
     <timetable-head-bar
       :semester="semesterName"
+      :hide-left="semesterIndex === 0"
+      :hide-right="semesterIndex === semesterArray.length - 1"
       @click-menu-button="showSelectedCourseList"
       @click-left="moveSemester(-1)"
       @click-right="moveSemester(1)"
@@ -194,6 +196,7 @@ export default defineComponent({
       semester: '2020-2021学年2学期',
       semesterIndex: 0,
       semesterJsonName: '',
+      semesterArray,
       isLoadingCourses: false,
       /** 课程数据 */
       allCourses: {} as AllCourses,

--- a/src/views/Timetable/components/TimetableHeadBar.vue
+++ b/src/views/Timetable/components/TimetableHeadBar.vue
@@ -6,7 +6,7 @@
         name="left"
         :height="16"
         :width="12"
-        class="icon"
+        :class="`icon ${hideLeft ? 'opacity-0' : 'cursor-pointer'}`"
         @click="handleClickLeft"
       />
       <span class="semester__name">
@@ -16,7 +16,7 @@
         name="right"
         :height="16"
         :width="12"
-        class="icon"
+        :class="`icon ${hideRight ? 'opacity-0' : 'cursor-pointer'}`"
         @click="handleClickRight"
       />
     </div>
@@ -42,6 +42,8 @@ export default defineComponent({
   },
   props: {
     semester: { type: String, required: true },
+    hideLeft: { type: Boolean, default: false },
+    hideRight: { type: Boolean, default: false },
   },
   emits: ['click-menu-button', 'click-left', 'click-right'],
   data() {
@@ -55,10 +57,14 @@ export default defineComponent({
       this.$emit('click-menu-button');
     },
     handleClickLeft() {
-      this.$emit('click-left');
+      if (!this.hideLeft) {
+        this.$emit('click-left');
+      }
     },
     handleClickRight() {
-      this.$emit('click-right');
+      if (!this.hideRight) {
+        this.$emit('click-right');
+      }
     },
   },
 });
@@ -84,7 +90,6 @@ export default defineComponent({
     display: flex;
     align-items: baseline;
     > .icon {
-      cursor: pointer;
       color: $primary-color;
     }
     > .semester__name {


### PR DESCRIPTION
RT

- 暂时没有去掉此前的 warning，以防特殊情况（比如用户手速过快，甚至快过了浏览器渲染）
- 采用 opacity 而非 v-if/v-show 是为了防止布局抖动