### PR TITLE
feat(pwa): using self-written service-worker.js now

### DIFF
--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -7,7 +7,7 @@ if (process.env.NODE_ENV === 'production') {
     ready() {
       console.log(
         'App is being served from cache by a service worker.\n'
-        + 'For more details, visit https://goo.gl/AFskqB',
+          + 'For more details, visit https://goo.gl/AFskqB',
       );
     },
     registered() {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,17 @@
+/* eslint-disable */
+
+self.__precacheManifest = [].concat(self.__precacheManifest || []);
+workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
+
+workbox.routing.registerRoute(
+  /\.(?:png|gif|jpg|jpeg|svg|css|html|txt|js|json)$/,
+  workbox.strategies.staleWhileRevalidate({
+    cacheName: 'fdxk',
+    plugins: [
+      new workbox.expiration.Plugin({
+        maxEntries: 240,
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+      }),
+    ],
+  }),
+);

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,6 +13,10 @@ module.exports = {
     msTileColor: '#60BDCA',
     appleMobileWebAppCapable: 'yes',
     appleMobileWebAppStatusBarStyle: 'black',
+    workboxPluginMode: 'InjectManifest',
+    workboxOptions: {
+      swSrc: 'src/service-worker.js',
+    },
 
     // configure the workbox plugin
     // workboxPluginMode: 'InjectManifest',


### PR DESCRIPTION
说实话我也不是特别肯定，各位测试测试；vue-cli 自动集成了 workbox-webpack-plugin，默认是自己生成 `service-worker.js` 如下

```js
/**
 * Welcome to your Workbox-powered service worker!
 *
 * You'll need to register this file in your web app and you should
 * disable HTTP caching for this file too.
 * See https://goo.gl/nhQhGp
 *
 * The rest of the code is auto-generated. Please don't update this file
 * directly; instead, make changes to your Workbox build configuration
 * and re-run your build process.
 * See https://goo.gl/2aRDsh
 */

importScripts("https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js");

importScripts(
  "/precache-manifest.5b51bf1e48406096ffa5a127d8fc7871.js"
);

workbox.core.setCacheNameDetails({prefix: "fdxk.info"});

self.addEventListener('message', (event) => {
  if (event.data && event.data.type === 'SKIP_WAITING') {
    self.skipWaiting();
  }
});

/**
 * The workboxSW.precacheAndRoute() method efficiently caches and responds to
 * requests for URLs in the manifest.
 * See https://goo.gl/S9QRab
 */
self.__precacheManifest = [].concat(self.__precacheManifest || []);
workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
```

现在改了 `vue.config.js` 配置、将使用自己写的 `service-worker.js`，其中 importScripts 两行会自动注入

可以看到原本就是使用了 precaching 方法，也就是在 service worker 安装时候 cache，理论上来说应该是会更新的（我的安卓手机也是会的，不知道为啥 ios 不行）

现在使用 `staleWhileRevalidate` 策略，也就是优先使用缓存同时后台拉取资源，如果有更新的话下次进入就会看到。


update:
大概率这里面有点问题，可以先上 vercel 测试一下