### PR TITLE
fix(rating): 修复评课详情页下方评课区压崩上方的问题

### DIFF
--- a/src/views/Rating/LectureDetail.vue
+++ b/src/views/Rating/LectureDetail.vue
@@ -6,7 +6,7 @@
     >
       <span class="title">课程评价</span>
     </rating-head-bar>
-    <div class="info-bar">
+    <div class="info-bar flex-shrink-0">
       <div class="info-bar__head">
         <div class="info-bar__head-left">
           <div class="lecture-title">

--- a/src/views/Rating/components/RatingHeadBar/RatingHeadBar.vue
+++ b/src/views/Rating/components/RatingHeadBar/RatingHeadBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="head-bar">
+  <div class="head-bar flex-shrink-0">
     <span
       v-if="isBackVisible"
       class="back-btn"


### PR DESCRIPTION
RT

此前仅在 IOS 会出现此问题，原因和此前课程详情卡片布局崩坏相同