### PR TITLE
去除 CI 中的 build 步骤

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn install
     - run: yarn run lint
-    - run: yarn run build --if-present
+    # - run: yarn run build --if-present
 #     - run: yarn test
 #       env:
 #         CI: true


### PR DESCRIPTION
## ✨ 工作描述

<!-- 在此处详细说明这个 PR 的工作。可参考以往的 PR。 -->

去除掉了 GitHub Actions CI 中 `yarn run build` 这一步，原因是现在 Vercel CI 中已经包含了 `build` 这个步骤，其可以检查出的错误和现在 CI 是一致的，而且速度会比现有 CI 快许多。

保留了 `yarn install` 和 `yarn run lint` 的 CI，以确保 review 时可以检查出 eslint 的报错。

## 🛠️ 对项目配置的改动

<!-- 在此处说明对项目中全局配置文件的改动理由（包括但不限于各种 *.config.js、.*rc、package.json 文件），若没有改动可以删去此节。 -->

<!-- - 改动了 `tailwind.config.js` 中 ... 字段。因为 ... -->
<!-- - 新引入了 ... 包。因为 ... -->

- 改变了 CI 流，见 PR 描述

## ✅ 检查清单

<!-- 以下四项必须保留，将 - [] 改为 - [x] 即可标记为完成，也可以在提交后直接点击 checkbox 切换状态。可以按照 PR 需求新增其他检查事项。 -->

- [x] （如有必要）更新了更新日志文件 `public/changeLog.json`
- [x] 在看板中同步了该 PR 的状态
- [x] 分配了 assignees, labels 和 reviewers
- [x] 在 Slack 中通知了 reviewers

<!-- Merge 前请确保完成了所有检查清单中的事项！ -->
<!-- 请在提交前通过 Preview 预览效果！ -->
