### PR TITLE
修复 max-len 警告

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,14 @@ module.exports = {
   rules: {
     'no-console': 1,
     'no-debugger': 1,
-    'max-len': ['warn', { ignorePattern: '^\\s*(class|d)="[^"]+"', code: 100 }],
+    'max-len': [
+      'warn',
+      {
+        code: 100,
+        ignorePattern: '^\\s*(class|d)=("[^"]+"|\\{`)',
+        ignoreComments: true,
+      },
+    ],
     'prefer-promise-reject-errors': 0,
     'implicit-arrow-linebreak': 0,
     'import/prefer-default-export': 0,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
   "prettier.singleQuote": true,
   "vetur.format.defaultFormatter.js": "prettier-eslint",
   "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/src/apis/lecture/types.ts
+++ b/src/apis/lecture/types.ts
@@ -81,7 +81,10 @@ export interface LectureDetail extends LectureType {
 }
 
 /** API 原始 Lecture Detail */
-export type LectureDetailDto = Omit<LectureDetail, 'difficulty' | 'nice' | 'workload' | 'recommended'> & {
+export type LectureDetailDto = Omit<
+  LectureDetail,
+  'difficulty' | 'nice' | 'workload' | 'recommended'
+> & {
   /** 难易程度 */
   difficulty: number | null;
   /** 给分好坏 */
@@ -90,7 +93,7 @@ export type LectureDetailDto = Omit<LectureDetail, 'difficulty' | 'nice' | 'work
   workload: number | null;
   /** 推荐指数 */
   recommended: number | null;
-}
+};
 
 /** 列表页 Lecture 项 */
 export type LectureItem = LectureType;

--- a/src/apis/rate/index.ts
+++ b/src/apis/rate/index.ts
@@ -25,7 +25,9 @@ const getRatingListByUser = async (req: {
 }> => {
   log.info('rateClient.getRatingListByUser', req);
   try {
-    const { data: { data } } = await API.get<GetRatesRespDto>('rates', {
+    const {
+      data: { data },
+    } = await API.get<GetRatesRespDto>('rates', {
       params: {
         user_id: req.userId,
         last_id: req.lastId,
@@ -51,7 +53,9 @@ const getRatingListByLecture = async (req: {
 }> => {
   log.info('rateClient.getRatingListByLecture', req);
   try {
-    const { data: { data } } = await API.get<GetRatesRespDto>('rates', {
+    const {
+      data: { data },
+    } = await API.get<GetRatesRespDto>('rates', {
       params: {
         lecture_id: req.lectureId,
         last_id: req.lastId,
@@ -76,7 +80,9 @@ const getRatingByLectureId = async (req: {
   data: RateForm | RateDraftDtoPartial;
 }> => {
   log.info('rateClient.getRatingById', req);
-  const { data: { data } } = await API.get<GetRatesLectureIdRespDto>(`rates/${req.lectureId}`, {
+  const {
+    data: { data },
+  } = await API.get<GetRatesLectureIdRespDto>(`rates/${req.lectureId}`, {
     params: {
       lecture_id: req.lectureId,
       last_id: req.lastId,
@@ -96,7 +102,9 @@ const getRatingList = async (req: {
   data: CardRatingItem[];
 }> => {
   log.info('rateClient.getRatingList');
-  const { data: { data } } = await API.get<GetRatesRespDto>('rates', {
+  const {
+    data: { data },
+  } = await API.get<GetRatesRespDto>('rates', {
     params: {
       last_id: req.lastId,
       limit: req.limit,
@@ -153,7 +161,9 @@ const deleteRating = async (req: {
   data: CardRatingItem[];
 }> => {
   log.info('rateClient.deleteRating', req);
-  const { data: { data } } = await API.delete<DeleteRatesLectureIdRespDto>(`rates/${req.lectureId}`);
+  const {
+    data: { data },
+  } = await API.delete<DeleteRatesLectureIdRespDto>(`rates/${req.lectureId}`);
   return { data: data.map(transferRateItemToCardRatingItem) };
 };
 

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -32,7 +32,9 @@ const getUserInfo = async (req: {
 }> => {
   log.info('userClient.getUserInfo', req);
   // TODO: 检查是否存在未登录却缺省 userId 调用该方法的情况，如果有，考虑如何规避发送该无效请求
-  const { data: { data } } = await API.get<GetUsersIdRespDto>(`users/${req.userId || getCurrentUserId() || ''}`);
+  const {
+    data: { data },
+  } = await API.get<GetUsersIdRespDto>(`users/${req.userId || getCurrentUserId() || ''}`);
   return data;
 };
 
@@ -63,7 +65,9 @@ const editUserInfo = async (req: {
   bio?: string;
 }> => {
   log.info('userClient.editUserInfo', req);
-  const { data: { data } } = await API.patch<PatchUsersIdRespDto>(`users/${req.uid || ''}`, req as PatchUsersIdReqDto);
+  const {
+    data: { data },
+  } = await API.patch<PatchUsersIdRespDto>(`users/${req.uid || ''}`, req as PatchUsersIdReqDto);
   return data;
 };
 

--- a/src/components/common/FSkeleton.vue
+++ b/src/components/common/FSkeleton.vue
@@ -14,7 +14,7 @@
         :key="i"
         class="h-4 mt-4 first:mt-0 bg-gray-200 rounded max-w-full"
         :style="{
-          width: widths[i - 1]
+          width: widths[i - 1],
         }"
       />
     </ul>
@@ -35,14 +35,20 @@ export default defineComponent({
     /** 每行宽度
      * 传入单个值为最后一行宽度，传入多个值则为从首行开始每行的宽度
      */
-    width: { type: [Number, String, Array] as PropType<number | string | Array<number | string>>, default: '100%' },
+    width: {
+      type: [Number, String, Array] as PropType<number | string | Array<number | string>>,
+      default: '100%',
+    },
   },
   setup(props) {
     const avatarSizeClass = computed(() => {
       switch (props.avatarSize) {
-        case 'base': return 'w-9 h-9';
-        case 'large': return 'w-20 h-20';
-        default: return '';
+        case 'base':
+          return 'w-9 h-9';
+        case 'large':
+          return 'w-20 h-20';
+        default:
+          return '';
       }
     });
     const widths = computed<string[]>(() => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,8 +1,10 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 
-const Timetable = () => import(/* webpackChunkName: "timetable" */ '@/views/Timetable/Timetable.vue');
+const Timetable = () =>
+  import(/* webpackChunkName: "timetable" */ '@/views/Timetable/Timetable.vue');
 const Rating = () => import(/* webpackChunkName: "rating" */ '@/views/Rating/Rating.vue');
-const Notification = () => import(/* webpackChunkName: "notification" */ '@/views/Notification/Notification.vue');
+const Notification = () =>
+  import(/* webpackChunkName: "notification" */ '@/views/Notification/Notification.vue');
 const About = () => import(/* webpackChunkName: "about" */ '@/views/About/About.vue');
 const User = () => import(/* webpackChunkName: "user" */ '@/views/User/User.vue');
 
@@ -49,7 +51,8 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/forgot-password',
     name: 'ForgotPassword',
-    component: () => import(/* webpackChunkName: "user-state" */ '@/views/UserStatus/ForgotPassword.vue'),
+    component: () =>
+      import(/* webpackChunkName: "user-state" */ '@/views/UserStatus/ForgotPassword.vue'),
   },
   {
     path: '/register',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,7 +5,13 @@ import { RateForm } from '@/components/listCard';
 
 /** 需要持久化保存的 state */
 const persistedState = {
-  localStorage: ['user', 'semester', 'selectedCoursesIds', 'selectedSectionsByDay', 'lastSawChangeLogDate'],
+  localStorage: [
+    'user',
+    'semester',
+    'selectedCoursesIds',
+    'selectedSectionsByDay',
+    'lastSawChangeLogDate',
+  ],
   sessionStorage: ['ratingForms'],
 };
 
@@ -137,7 +143,7 @@ const store = createStore({
       state.hasFetchedSelectedCourses = true;
     },
     /** 设置 ratingForms */
-    setRatingForm(state, payload: { lectureId: string, formData: RateForm }) {
+    setRatingForm(state, payload: { lectureId: string; formData: RateForm }) {
       const { lectureId, formData } = payload;
       state.ratingForms[lectureId] = formData;
     },

--- a/src/views/Rating/RatingForm.vue
+++ b/src/views/Rating/RatingForm.vue
@@ -315,25 +315,31 @@ export default defineComponent({
     /** 对比字段，如果没有变化返回 undefined，否则返回新的值 */
     editedValue<K extends keyof RateForm>(fieldName: K): RateForm[K] | undefined {
       if (this.formData[fieldName] === this.savedRateDraft[fieldName]) return undefined;
-      if (fieldName === 'content' && this.formData.content?.trim() === this.savedRateDraft.content?.trim()) return undefined;
+      if (
+        fieldName === 'content'
+        && this.formData.content?.trim() === this.savedRateDraft.content?.trim()
+      ) { return undefined; }
       return this.formData[fieldName];
     },
     /** 点击保存按钮 */
     handleClickSaveDraft() {
       this.isLoading = true;
-      rateDraftClient.saveDraft({
-        lectureId: this.lectureId,
-        difficulty: this.editedValue('difficulty'),
-        nice: this.editedValue('nice'),
-        workload: this.editedValue('workload'),
-        recommended: this.editedValue('recommended'),
-        content: this.editedValue('content'),
-      }).then(() => {
-        this.$message.success('保存草稿成功！');
-        this.savedRateDraft = { ...this.formData };
-      }).finally(() => {
-        this.isLoading = false;
-      });
+      rateDraftClient
+        .saveDraft({
+          lectureId: this.lectureId,
+          difficulty: this.editedValue('difficulty'),
+          nice: this.editedValue('nice'),
+          workload: this.editedValue('workload'),
+          recommended: this.editedValue('recommended'),
+          content: this.editedValue('content'),
+        })
+        .then(() => {
+          this.$message.success('保存草稿成功！');
+          this.savedRateDraft = { ...this.formData };
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
     },
     /** 点击发布按钮 */
     handleClickSubmit() {

--- a/src/views/Rating/components/LectureDetailInfo.vue
+++ b/src/views/Rating/components/LectureDetailInfo.vue
@@ -48,10 +48,16 @@ export default defineComponent({
   },
   setup(props) {
     const withdrawable = computed(() => {
-      if (props.lectureInfo.detailInfo.withdrawable === 'true' || props.lectureInfo.detailInfo.withdrawable === '是') {
+      if (
+        props.lectureInfo.detailInfo.withdrawable === 'true'
+        || props.lectureInfo.detailInfo.withdrawable === '是'
+      ) {
         return '是';
       }
-      if (props.lectureInfo.detailInfo.withdrawable === '否' || props.lectureInfo.detailInfo.withdrawable === '') {
+      if (
+        props.lectureInfo.detailInfo.withdrawable === '否'
+        || props.lectureInfo.detailInfo.withdrawable === ''
+      ) {
         return '否';
       }
       return '未知';

--- a/src/views/User/User.vue
+++ b/src/views/User/User.vue
@@ -66,9 +66,7 @@
             </span>
           </div>
           <span class="bio text-gray-500">
-            {{
-              userProfile.bio || ''
-            }}
+            {{ userProfile.bio || '' }}
           </span>
         </div>
       </div>
@@ -195,7 +193,8 @@ export default defineComponent({
     const router = useRouter();
     const currentUser = computed(() => store.state.user);
     const userLoggedIn = computed(() => store.getters.userLoggedIn);
-    const isCurrentUser = () => userLoggedIn.value && (props.userId === currentUser.value.id || props.userId === '');
+    const isCurrentUser = () =>
+      userLoggedIn.value && (props.userId === currentUser.value.id || props.userId === '');
     const setUserProfile = (profile: UserProfile) => store.commit('setUserProfile', profile);
 
     const logout = () => {
@@ -256,14 +255,13 @@ export default defineComponent({
     /** 最近一次看过的更新日志日期 */
     const lastSawChangeLogDate = computed(() => store.state.lastSawChangeLogDate);
 
-    axios.get<{ date: string }[]>('changeLog.json')
-      .then(({ data }) => {
-        /** 最新的更新日志日期 */
-        const latestDate = data.map((d) => d.date).sort((a, b) => (a < b ? 1 : -1))[0];
-        if (latestDate !== lastSawChangeLogDate.value) {
-          isAboutBadgeVisible.value = true;
-        }
-      });
+    axios.get<{ date: string }[]>('changeLog.json').then(({ data }) => {
+      /** 最新的更新日志日期 */
+      const latestDate = data.map((d) => d.date).sort((a, b) => (a < b ? 1 : -1))[0];
+      if (latestDate !== lastSawChangeLogDate.value) {
+        isAboutBadgeVisible.value = true;
+      }
+    });
 
     return {
       processAvatar,


### PR DESCRIPTION
## ✨ 工作描述

<!-- 在此处详细说明这个 PR 的工作。可参考以往的 PR。 -->

fix #149 

- 将所有运行 `yarn lint` 报警告的文件用 prettier 格式化
- 另行增加了 `max-len` `ignoreComments: true` 选项，以对注释忽略 `max-len`
- 修改了 `max-len` `ignorePattern` 正则，增加了对 JSX 中 `class` 的支持

## 🍀 给 Reviewer 的辅助信息

<!-- 在此处提供需要 Reviewer 注意的和有助于 Reviewer 工作的信息，可以参考下方示例或以往的 PR。 -->

<!-- - ... 需要重点 review。因为 ...（可能破坏现有功能 / 逻辑上有较大变动 / ...） -->
<!-- - ... 的改动不需要重点关注代码，可以通过 Vercel 预览来测试 -->
<!-- - 通过（逐 commits? / 用 VSCode diff? / ...）的方式 review 会更加容易。因为 ... （各 commits 之间工作相互独立 / 修改了缩进 / ...） -->

- 着重看看对 `ignorePattern` 修改的正则是否正确即可，其他位置都是 pretteir 自动改的，应该不会引入新错误

## 🛠️ 对项目配置的改动

<!-- 在此处说明对项目中全局配置文件的改动理由（包括但不限于各种 *.config.js、.*rc、package.json 文件），若没有改动可以删去此节。 -->

<!-- - 改动了 `tailwind.config.js` 中 ... 字段。因为 ... -->
<!-- - 新引入了 ... 包。因为 ... -->

- 修改了 ESLint `max-len` 规则，具体看上文
- 将 VSCode 设置中对于普通 TS 文件的默认格式化程序也设为 Prettier

## ✅ 检查清单

<!-- 以下四项必须保留，将 - [] 改为 - [x] 即可标记为完成，也可以在提交后直接点击 checkbox 切换状态。可以按照 PR 需求新增其他检查事项。 -->

- [x] 更新了更新日志文件 `public/changeLog.json`（若有必要）
- [x] 链接了对应 Issues（若有）
- [x] 指定了对应 Projects（若有必要）
- [x] 分配了 assignees, labels 和 reviewers
- [x] 在 Slack 中通知了 reviewers

<!-- Merge 前请确保完成了所有检查清单中的事项！ -->
<!-- 请在提交前通过 Preview 预览效果！ -->
